### PR TITLE
Exclude unnecessary files when downloading the plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,12 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Ignore some files when exporting to a ZIP.
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/icon.png         export-ignore
+/icon.png.import  export-ignore
+/README.md        export-ignore
+/LICENSE          export-ignore
+/project.godot    export-ignore
+/images           export-ignore

--- a/addons/float_script_editor/LICENSE
+++ b/addons/float_script_editor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 热心市民张学徒
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
根据文档中的建议，利用 .gitattributes 文件忽略掉插件文件夹外的无关文件。这样在 Godot 中下载插件后无需调整就可以直接使用。

另外因为 LICENSE 文件是在根目录的，这里也一并忽略，并遵循文档中的建议**复制**到插件文件夹中。